### PR TITLE
#165016586 Update by account number not by id

### DIFF
--- a/server/controllers/account.js
+++ b/server/controllers/account.js
@@ -16,7 +16,8 @@ exports.createAccount = (req, res) =>{
         lastName : req.body.lastName,
         email : req.body.email,
         type : req.body.type,
-        openingBalance : req.body.openingBalance
+        openingBalance : req.body.openingBalance,
+        status: req.body.status || "activate"
     }
 
     accounts.push(account)
@@ -25,23 +26,25 @@ exports.createAccount = (req, res) =>{
 
 // UPDATE ACCOUNT
 exports.updateAccount = (req, res) =>{
-    // Find account with a given id
-    let account = accounts.find(acc => acc.id === parseInt(req.params.id))
-    if(!account) return res.status(404).json({ status:404, error: "Account with the given id is not found"})
+    // Find account with a given account number
+    let account = accounts.find(acc => acc.accountNumber === parseInt(req.params.accountNumber))
+    // console.log(account)
+    if(!account) return res.status(404).json({ status:404, error: "Account with the given account number is not found"})
 
-    const { error } = validate.validateAccount(req.body)
-    if(error) return res.status(400).json({ status: 400, error: error.dtails[0].message })
+    const { error } = validate.validateUpdate(req.body)
+    if(error) return res.status(400).json({ status: 400, error: error.details[0].message })
 
-    account.accountNumber = req.body.accountNumber
+    account.status = req.body.status
     return res.status(200).json({ status: 200, message: "Updated successfully", data: account })
 }
 
 // DELETE ACCOUNT
 exports.deleteAccount = (req, res) =>{
-    // Find account with a given ID
-    let account = accounts.fill(acc => acc.id === parseInt(req.params.id))
-    if(!account) return res.status(404).json({ status: 404, error: "Account with the given ID is not found" })
-
+    // Find account with a given account number
+    let account = accounts.find(acc => acc.accountNumber === parseInt(req.params.accountNumber))
+    console.log(account)
+    if(!account) return res.status(404).json({ status: 404, error: "Account with the given account number is not found" })
+    
     const index = accounts.indexOf(account)
     accounts.splice(index)
 

--- a/server/helpers/account-validation.js
+++ b/server/helpers/account-validation.js
@@ -7,8 +7,17 @@ exports.validateAccount = (account) =>{
         lastName : joi.string().min(3).required(),
         email : joi.string().email().required(),
         type : joi.string().valid('saving', 'current'),
-        openingBalance : joi.number().required()
+        openingBalance : joi.number().required(),
+        status: joi.string().valid('activate', 'dormant')
     }
 
     return joi.validate(account, accountSchema)
+}
+
+exports.validateUpdate = (update) =>{
+    const updateSchema = {
+        status: joi.string().valid('activate', 'dormant')
+    }
+
+    return joi.validate(update, updateSchema)
 }

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -9,7 +9,7 @@ const router  = express.Router()
 router.post('/auth/signup', signupCtrl.signup)
 router.post('/auth/signin', loginCtrl.login)
 router.post('/accounts', auth, accountCtrl.createAccount)
-router.patch('/accounts/:id', auth, accountCtrl.updateAccount)
-router.delete('/accounts/:id', auth, accountCtrl.deleteAccount)
+router.patch('/accounts/:accountNumber', auth, accountCtrl.updateAccount)
+router.delete('/accounts/:accountNumber', auth, accountCtrl.deleteAccount)
 
 export default router


### PR DESCRIPTION
#### What does this PR do?
Fix the issue of activating or deactivating bank account by id instead of account number
#### How can this be manually tested?
1. clone the repo ```git clone https://github.com/Joe-Joseph/Banka.git```
2. cd inside the folder
3. run ```npm install```
4. run ```npm run start```
5. Open Postman
6. test this endpoint ```/api/v1/accounts/1111111``` with ```PATCH``` method  on port ```4000``` where ```1111111``` is an account number of the account you want to activate or deactivate
your url should look like this ```localhost:4000/api/v1/accounts/1111111```
#### Relevant pivotal tracker story
[#165016586](https://www.pivotaltracker.com/story/show/165016586)